### PR TITLE
new tables added at md-intro page

### DIFF
--- a/content/en/markdown-introduction.md
+++ b/content/en/markdown-introduction.md
@@ -19,6 +19,8 @@ For further details, please see https://github.github.com/gfm/
 
 <img width="808" alt="image" src="https://user-images.githubusercontent.com/3258579/182511736-dd4aac7c-7fc6-41fd-bca2-f260213d24f0.png">
 
+## Markdown for MD2HTML Tool
+These markdown constructors are interpreted by the [MD2HTML](https://standardshub.github.io/markdown_guidelines/md2html-overview) developed by Standards Hub. The [MD2HTML](https://standardshub.github.io/markdown_guidelines/md2html-overview)` automatically buils a PDF and HTML document for each markdown document.
 
 <table>
   <thead>
@@ -30,18 +32,11 @@ For further details, please see https://github.github.com/gfm/
   <tbody>
     <tr>
       <td>
-        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#headings"
-          target="_blank">Headings</a><br>
-        <ul>
-          <li><a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-section"
-              target="_blank">Links to a Section</a></li>
-          <li><a
-              href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-section-from-within-a-table"
-              target="_blank">Links to a Section From Within a Table</a></li>
-        </ul>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#headings" target="_blank">Headings</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-section" target="_blank">Links to a Section</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-section-from-within-a-table" target="_blank">Links to a Section From Within a Table</a>
       </td>
       <td>
-        support-markdown-syntax.md
         <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#paragraph"
           target="_blank">Paragraph</a><br>
         <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#block-quote" target="_blank">Block
@@ -57,16 +52,8 @@ For further details, please see https://github.github.com/gfm/
       <td>
         <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#tables"
           target="_blank">Tables</a><br>
-        <ul>
-          <li>
-            <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-table"
-              target="_blank">Links to a Table</a><br>
-          </li>
-          <li>
-            <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-table-from-within-a-table"
-              target="_blank">Links to a Figure From Within a Table</a><br>
-          </li>
-        </ul>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-table"  target="_blank">Links to a Table</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-table-from-within-a-table" target="_blank">Links to a Figure From Within a Table</a><br>
       </td>
       <td>
         <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#ordered-list"
@@ -81,16 +68,8 @@ For further details, please see https://github.github.com/gfm/
       <td>
         <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#figures"
           target="_blank">Figures</a><br>
-        <ul>
-          <li>
-            <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#link-to-a-figure"
-              target="_blank">Links to a Figure</a><br>
-          </li>
-          <li>
-            <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-figure-from-within-a-table"
-              target="_blank">Links to a Figure From Within a Table</a><br>
-          </li>
-        </ul>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#link-to-a-figure"  target="_blank">Links to a Figure</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-figure-from-within-a-table" target="_blank">Links 
       </td>
       <td></td>
     </tr>

--- a/content/en/markdown-introduction.md
+++ b/content/en/markdown-introduction.md
@@ -18,3 +18,139 @@ It allows content to be decoupled from how is displayed.
 For further details, please see https://github.github.com/gfm/
 
 <img width="808" alt="image" src="https://user-images.githubusercontent.com/3258579/182511736-dd4aac7c-7fc6-41fd-bca2-f260213d24f0.png">
+
+
+<table>
+  <thead>
+    <tr>
+      <th>Table/Figures/Sections</th>
+      <th>Paragraphs</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#headings"
+          target="_blank">Headings</a><br>
+        <ul>
+          <li><a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-section"
+              target="_blank">Links to a Section</a></li>
+          <li><a
+              href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-section-from-within-a-table"
+              target="_blank">Links to a Section From Within a Table</a></li>
+        </ul>
+      </td>
+      <td>
+        support-markdown-syntax.md
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#paragraph"
+          target="_blank">Paragraph</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#block-quote" target="_blank">Block
+          quote</a>
+        <br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#preformated-text"
+          target="_blank">Performed Text</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#code-with-syntax-highlighing"
+          target="_blank">Code With Syntax Highlighting</a><br>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#tables"
+          target="_blank">Tables</a><br>
+        <ul>
+          <li>
+            <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-table"
+              target="_blank">Links to a Table</a><br>
+          </li>
+          <li>
+            <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-table-from-within-a-table"
+              target="_blank">Links to a Figure From Within a Table</a><br>
+          </li>
+        </ul>
+      </td>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#ordered-list"
+          target="_blank">Ordered List</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#unordered-list"
+          target="_blank">Unordered List</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#nested-list" target="_blank">Nested
+          List</a><br>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#figures"
+          target="_blank">Figures</a><br>
+        <ul>
+          <li>
+            <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#link-to-a-figure"
+              target="_blank">Links to a Figure</a><br>
+          </li>
+          <li>
+            <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#links-to-a-figure-from-within-a-table"
+              target="_blank">Links to a Figure From Within a Table</a><br>
+          </li>
+        </ul>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#further-links"
+          target="_blank">Furher Links<br>
+          <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#further-links-from-within-a-table"
+            target="_blank">Furher Links From Within a Table<br>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr>
+      <th>Breaks</th>
+      <th>Other</th>
+      <th>Text</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#line-breaks" target="_blank">Line
+          Breaks</a><br>
+      </td>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#ignore-markdown-formatting"
+          target="_blank">Ignore Markdown Formatting</a><br>
+      </td>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#important-text"
+          target="_blank">Important Text</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#emphasised-text"
+          target="_blank">Emphasised Text</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#combined-important--emphasised-text"
+          target="_blank">Combined Important & Emphasised Text</a><br>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#strikethrough-text"
+          target="_blank">Strikethrough Text</a><br>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#non-breaking-space"
+          target="_blank">Non-breaking Space</a><br>
+      </td>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#constructors-involving-formatting"
+          target="_blank">Constructors Involving Formatting</a><br>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://standardshub.github.io/markdown_guidelines/md2html-extended#page-break" target="_blank">Page
+          Break</a><br>
+      </td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
This one addresses [Add Markdown table to new website github.standardshub.io #62](https://github.com/OpenMobileAlliance/oma_working_groups/issues/62) issue.

Please review.

